### PR TITLE
fix: update Docker image reference for web service to use latest vers…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
 
   web:
-    image: ecommerce-backend:prod
+    image: ghcr.io/joekariuki3/ecommerce_backend:latest
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
This pull request updates the Docker image used by the `web` service in the `docker-compose.yml` file to pull from a GitHub Container Registry instead of a local image.

- **Deployment configuration:**
  * Updated the `web` service in `docker-compose.yml` to use the `ghcr.io/joekariuki3/ecommerce_backend:latest` image instead of the local `ecommerce-backend:prod` image.…ion from GitHub registry