### PR TITLE
Develop

### DIFF
--- a/apps/catalog/views.py
+++ b/apps/catalog/views.py
@@ -1,4 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import filters, viewsets
 
 from .models import Category, Product
@@ -39,3 +41,29 @@ class ProductViewSet(viewsets.ModelViewSet):
         filters.OrderingFilter,
         filters.SearchFilter,
     )
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "category_id",
+                openapi.IN_QUERY,
+                description="Filter products by category ID (exact match) (UUID).",
+                type=openapi.TYPE_STRING,
+            ),
+            openapi.Parameter(
+                "ordering",
+                openapi.IN_QUERY,
+                description="Order products by field. Options: price, name, created_at (prefix with '-' for descending, e.g., -price).",
+                type=openapi.TYPE_STRING,
+                enum=["price", "name", "created_at", "-price", "-name", "-created_at"],
+            ),
+            openapi.Parameter(
+                "search",
+                openapi.IN_QUERY,
+                description="Search products by name (case-insensitive partial match).",
+                type=openapi.TYPE_STRING,
+            ),
+        ],
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)


### PR DESCRIPTION
This pull request enhances the API documentation for the product listing endpoint in the catalog app by adding detailed Swagger schema annotations. This makes it easier for frontend developers and API consumers to understand how to filter, order, and search products using query parameters.

API documentation improvements:

* Added `swagger_auto_schema` annotation to the `list` method of `ProductViewSet` to document query parameters for filtering by `category_id`, ordering by fields (with enum options), and searching by product name.
* Imported `openapi` and `swagger_auto_schema` from `drf_yasg` to support the new documentation features.